### PR TITLE
添加工作流、背景音乐和模板目录的挂载到docker-compose配置中

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,9 @@ services:
       # data/ contains: users/, bgm/, templates/, workflows/ (custom resources)
       - ./data:/app/data
       - ./output:/app/output
+      - ./workflows:/app/workflows
+      - ./bgm:/app/bgm
+      - ./templates:/app/templates
       # Note: Default resources (bgm/, templates/, workflows/) are baked into the image
       # Custom resources in data/* will override defaults
     environment:
@@ -95,6 +98,9 @@ services:
       # data/ contains: users/, bgm/, templates/, workflows/ (custom resources)
       - ./data:/app/data
       - ./output:/app/output
+      - ./workflows:/app/workflows
+      - ./bgm:/app/bgm
+      - ./templates:/app/templates
       # Note: Default resources (bgm/, templates/, workflows/) are baked into the image
       # Custom resources in data/* will override defaults
     environment:


### PR DESCRIPTION
不挂载目录到容器中，根本无法使用自己的工作流
按照readme应该默认挂载才合适